### PR TITLE
feat(api): implementar CRUD completo de productos con validaciones y Swagger

### DIFF
--- a/api/src/common/validators/is-ecuador-ruc.ts
+++ b/api/src/common/validators/is-ecuador-ruc.ts
@@ -1,0 +1,31 @@
+import { registerDecorator, ValidationArguments, ValidationOptions } from 'class-validator';
+
+/**
+ * Validación básica de RUC Ecuador:
+ * - 13 dígitos
+ * - Los 3 últimos dígitos no pueden ser "000" (establecimiento)
+ * (Suficiente para tu flujo actual; se puede endurecer luego)
+ */
+export function IsEcuadorRuc(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'IsEcuadorRuc',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any) {
+          if (typeof value !== 'string') return false;
+          const ruc = value.trim();
+          if (!/^\d{13}$/.test(ruc)) return false;
+          const estab = ruc.slice(-3);
+          if (estab === '000') return false;
+          return true;
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} debe ser un RUC ecuatoriano válido de 13 dígitos (los últimos 3 ≠ "000")`;
+        },
+      },
+    });
+  };
+}

--- a/api/src/products/dto/create-product.dto.ts
+++ b/api/src/products/dto/create-product.dto.ts
@@ -1,1 +1,16 @@
-export class CreateProductDto {}
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateProductDto {
+  @ApiProperty({ example: 'Camisa básica' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  name!: string;
+
+  @ApiPropertyOptional({ example: 'CAM-001', description: 'Único por compañía; opcional' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  code?: string | null;
+}

--- a/api/src/products/dto/list-products.dto.ts
+++ b/api/src/products/dto/list-products.dto.ts
@@ -1,17 +1,31 @@
-import { IsInt, IsNotEmpty, IsOptional, IsString, Max, Min, Matches } from 'class-validator';
-import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, Max, Min, } from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+import { IsEcuadorRuc } from '../../common/validators/is-ecuador-ruc';
 
 export class ListProductsDto {
-  // RUC de 13 dígitos (obligatorio)
-  @Matches(/^\d{13}$/, { message: 'ruc debe tener 13 dígitos' })
+  @ApiProperty({ example: '1790012345001', description: 'RUC de la empresa (EC)' })
+  @IsString()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsEcuadorRuc()
   ruc!: string;
 
-  @IsOptional() @IsString()
+  @ApiPropertyOptional({ example: 'camisa' })
+  @IsOptional()
+  @IsString()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   q?: string;
 
-  @IsOptional() @Type(() => Number) @IsInt() @Min(1)
-  page: number = 1;
+  @ApiPropertyOptional({ example: 1, default: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page = 1;
 
-  @IsOptional() @Type(() => Number) @IsInt() @Min(1) @Max(100)
-  limit: number = 20;
+  @ApiPropertyOptional({ example: 20, default: 20 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit = 20;
 }

--- a/api/src/products/dto/ruc-query.dto.ts
+++ b/api/src/products/dto/ruc-query.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Matches } from 'class-validator';
+
+export class RucQueryDto {
+  @ApiProperty({ example: '1790012345001', description: 'RUC de la empresa (13 dígitos)' })
+  @IsString()
+  @Matches(/^\d{13}$/, { message: 'ruc debe tener 13 dígitos' })
+  ruc!: string;
+}

--- a/api/src/products/dto/update-product.dto.ts
+++ b/api/src/products/dto/update-product.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateProductDto } from './create-product.dto';
 
 export class UpdateProductDto extends PartialType(CreateProductDto) {}

--- a/api/src/products/products.controller.ts
+++ b/api/src/products/products.controller.ts
@@ -1,43 +1,69 @@
-// src/products/products.controller.ts
-import { BadRequestException, Controller, Get, Param, Query } from '@nestjs/common';
-import { ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { ApiBody, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ProductsService } from './products.service';
 import { ListProductsDto } from './dto/list-products.dto';
-import { PrismaService } from '../../prisma/prisma.service';
+import { CreateProductDto } from './dto/create-product.dto';
+import { UpdateProductDto } from './dto/update-product.dto';
+import { RucQueryDto } from './dto/ruc-query.dto';
 
 @ApiTags('products')
 @Controller('products')
 export class ProductsController {
-  constructor(
-    private readonly service: ProductsService,
-    private readonly prisma: PrismaService,
-  ) {}
+  constructor(private readonly service: ProductsService) {}
 
+  // GET /products?ruc=&q=&page=&limit=
   @Get()
-  @ApiQuery({ name: 'ruc', type: String, required: true, example: '1790012345001' })
-  @ApiQuery({ name: 'q', type: String, required: false })
-  @ApiQuery({ name: 'page', type: Number, required: false, example: 1 })
-  @ApiQuery({ name: 'limit', type: Number, required: false, example: 20 })
+  @ApiResponse({ status: 200, description: 'Listado paginado de productos' })
   async list(@Query() dto: ListProductsDto) {
-    const companyId = await this.resolveCompanyIdByRuc(dto.ruc);
     return this.service.list({
-      companyId,
+      ruc: dto.ruc,
       q: dto.q,
       page: dto.page,
       limit: dto.limit,
     });
   }
 
+  // GET /products/:id?ruc=
   @Get(':id')
-  @ApiQuery({ name: 'ruc', type: String, required: true, example: '1790012345001' })
-  async getOne(@Param('id') id: string, @Query() dto: ListProductsDto) {
-    const companyId = await this.resolveCompanyIdByRuc(dto.ruc);
-    return this.service.findOne(companyId, id);
+  @ApiQuery({ name: 'ruc', required: true })
+  @ApiResponse({ status: 200, description: 'Detalle de producto (incluye variantes)' })
+  @ApiResponse({ status: 404, description: 'Producto no encontrado' })
+  async getOne(@Param('id') id: string, @Query() q: RucQueryDto) {
+    return this.service.findOne(q.ruc, id);
   }
 
-  private async resolveCompanyIdByRuc(ruc: string) {
-    const company = await this.prisma.company.findUnique({ where: { ruc } });
-    if (!company) throw new BadRequestException('Empresa no encontrada para ese RUC');
-    return company.id;
+  // POST /products?ruc=
+  @Post()
+  @ApiQuery({ name: 'ruc', required: true })
+  @ApiBody({ type: CreateProductDto })
+  @ApiResponse({ status: 201, description: 'Producto creado' })
+  @ApiResponse({ status: 409, description: 'Conflicto: code ya existe en la empresa' })
+  async create(@Query() q: RucQueryDto, @Body() body: CreateProductDto) {
+    return this.service.create(q.ruc, body);
+  }
+
+  // PATCH /products/:id?ruc=
+  @Patch(':id')
+  @ApiQuery({ name: 'ruc', required: true })
+  @ApiBody({ type: UpdateProductDto })
+  @ApiResponse({ status: 200, description: 'Producto actualizado' })
+  @ApiResponse({ status: 404, description: 'Producto no encontrado' })
+  @ApiResponse({ status: 409, description: 'Conflicto: code ya existe en la empresa' })
+  async update(
+    @Param('id') id: string,
+    @Query() q: RucQueryDto,
+    @Body() body: UpdateProductDto,
+  ) {
+    return this.service.update(q.ruc, id, body);
+  }
+
+  // DELETE /products/:id?ruc=
+  @Delete(':id')
+  @ApiQuery({ name: 'ruc', required: true })
+  @ApiResponse({ status: 200, description: 'Producto eliminado' })
+  @ApiResponse({ status: 404, description: 'Producto no encontrado' })
+  @ApiResponse({ status: 409, description: 'No se puede eliminar: tiene variantes' })
+  async remove(@Param('id') id: string, @Query() q: RucQueryDto) {
+    return this.service.remove(q.ruc, id);
   }
 }

--- a/api/src/products/products.module.ts
+++ b/api/src/products/products.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ProductsController } from './products.controller';
 import { ProductsService } from './products.service';
-import { PrismaClient } from '@prisma/client';
+import { PrismaModule } from '../../prisma/prisma.module';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ProductsController],
-  providers: [ProductsService, PrismaClient], // o PrismaService si ya lo tienes
+  providers: [ProductsService],
   exports: [ProductsService],
 })
 export class ProductsModule {}

--- a/api/src/products/products.service.ts
+++ b/api/src/products/products.service.ts
@@ -1,25 +1,51 @@
-import { Injectable } from '@nestjs/common';
-import { Prisma, PrismaClient } from '@prisma/client';
+// src/products/products.service.ts
+import {
+  Injectable,
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class ProductsService {
-  constructor(private readonly prisma: PrismaClient) {}
+  constructor(private readonly prisma: PrismaService) {}
 
-  async list(dto: { companyId: string; q?: string; page: number; limit: number }) {
-    const { companyId, q, page, limit } = dto;
+  private async getCompanyOrThrow(ruc: string) {
+    const company = await this.prisma.company.findUnique({ where: { ruc } });
+    if (!company) throw new NotFoundException('Empresa no encontrada para el RUC');
+    return company;
+  }
+
+  private normalizeCode(code?: string | null) {
+    const v = (code ?? '').trim();
+    return v ? v.toUpperCase() : null;
+  }
+
+  async list(dto: { ruc: string; q?: string; page: number; limit: number }) {
+    const { ruc, q, page, limit } = dto;
+
+    if (page < 1 || limit < 1 || limit > 100) {
+      throw new BadRequestException('Parámetros de paginación inválidos');
+    }
+
+    const company = await this.getCompanyOrThrow(ruc);
 
     const where: Prisma.ProductWhereInput = {
-      companyId,
+      companyId: company.id,
       ...(q
         ? {
             OR: [
-              { name: { contains: q, mode: 'insensitive' } },
-              { code: { contains: q, mode: 'insensitive' } },
-              { variants: { some: { sku: { contains: q, mode: 'insensitive' } } } },
+              { name: { contains: q, mode: 'insensitive' as const } },
+              { code: { contains: q, mode: 'insensitive' as const } },
+              { variants: { some: { sku: { contains: q, mode: 'insensitive' as const } } } },
             ],
           }
         : {}),
     };
+
+     const orderBy: Prisma.ProductOrderByWithRelationInput = { createdAt: 'desc' };
 
     const [items, total] = await this.prisma.$transaction([
       this.prisma.product.findMany({
@@ -29,20 +55,109 @@ export class ProductsService {
             select: { id: true, sku: true, color: true, size: true, price: true, stock: true },
           },
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy,
         skip: (page - 1) * limit,
         take: limit,
       }),
       this.prisma.product.count({ where }),
     ]);
 
-    return { items, total, page, limit };
+    return {
+      items,
+      total,
+      page,
+      limit,
+      pages: Math.ceil(total / limit),
+    };
   }
 
-  async findOne(companyId: string, id: string) {
-    return this.prisma.product.findFirst({
-      where: { id, companyId },
+  async findOne(ruc: string, id: string) {
+    const company = await this.getCompanyOrThrow(ruc);
+
+    const product = await this.prisma.product.findFirst({
+      where: { id, companyId: company.id },
       include: { variants: true },
     });
+    if (!product) throw new NotFoundException('Producto no encontrado');
+    return product;
+  }
+
+  async create(ruc: string, dto: { name: string; code?: string | null }) {
+    const company = await this.getCompanyOrThrow(ruc);
+
+    try {
+      return await this.prisma.product.create({
+        data: {
+          name: dto.name.trim(),
+          code: this.normalizeCode(dto.code),
+          companyId: company.id,
+        },
+      });
+    } catch (e: any) {
+      if (e.code === 'P2002') {
+        throw new ConflictException('El código de producto ya existe en esta empresa');
+      }
+      throw e;
+    }
+  }
+
+async update(ruc: string, id: string, dto: { name?: string; code?: string | null }) {
+  const company = await this.getCompanyOrThrow(ruc);
+
+  const existing = await this.prisma.product.findFirst({
+    where: { id, companyId: company.id },
+  });
+  if (!existing) throw new NotFoundException('Producto no encontrado');
+
+  // Normaliza y compara el code entrante con el existente
+  let nextCode = existing.code;
+  if (dto.code !== undefined) {
+    const normalized = this.normalizeCode(dto.code);
+    // Si es igual al actual, no intentamos reescribirlo (evita P2002 “único”)
+    nextCode = normalized === existing.code ? existing.code : normalized;
+  }
+
+  // Si no hay cambios reales, puedes opcionalmente devolver el existente
+  const nextName = dto.name?.trim() ?? existing.name;
+  if (nextName === existing.name && nextCode === existing.code) {
+    return existing; // no-op
+  }
+
+  try {
+    return await this.prisma.product.update({
+      where: { id: existing.id },
+      data: {
+        name: nextName,
+        code: nextCode,
+      },
+    });
+  } catch (e: any) {
+    if (e.code === 'P2002') {
+      // @@unique([companyId, code]) — otro producto ya tiene ese code
+      throw new ConflictException('El código de producto ya existe en esta empresa');
+    }
+    throw e;
+  }
+}
+
+
+  async remove(ruc: string, id: string) {
+    const company = await this.getCompanyOrThrow(ruc);
+
+    const product = await this.prisma.product.findFirst({
+      where: { id, companyId: company.id },
+    });
+    if (!product) throw new NotFoundException('Producto no encontrado');
+
+    // Contar variantes sin depender de _count para evitar error de tipos
+    const variantsCount = await this.prisma.variant.count({
+      where: { productId: product.id },
+    });
+    if (variantsCount > 0) {
+      throw new ConflictException('No se puede eliminar: el producto tiene variantes');
+    }
+
+    await this.prisma.product.delete({ where: { id: product.id } });
+    return { ok: true };
   }
 }


### PR DESCRIPTION
- GET /products con búsqueda (name, code, variants.sku) y paginación
- GET /products/:id con detalle y variantes
- POST /products con validación de name y code único por compañía
- PATCH /products/:id con actualización parcial y manejo correcto de code
- DELETE /products/:id restringido si tiene variantes
- Validaciones DTOs (RUC, name, paginación)
- Documentación en Swagger con ejemplos de request/response